### PR TITLE
Spotify: removed earlier spotify card

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 ## 🎧🎧 Listening To
 
-[![Spotify](https://novatorem-omega-one.vercel.app/api/spotify)](https://open.spotify.com/user/https://novatorem-omega-one.vercel.app)
+![Spotify recently played](https://spotify-recently-played-readme.vercel.app/api?user=5n2bcwz8z1ow9ew8oc0oavrh9&width=600)
 
 ## 🔗 Connect with me
 


### PR DESCRIPTION
The earlier spotify card was not working as expected. So, I have removed it and added a new card for the same. this card is not dynamic and it shows recently played songs. It is just a static card with a link to my spotify profile.