### PR TITLE
Fix achievements and coding habits by switching to maintained fork

### DIFF
--- a/.github/workflows/coding-habits.yml
+++ b/.github/workflows/coding-habits.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     steps:
       - name: Midly interesting facts
-        uses: lowlighter/metrics@latest
+        uses: dkhokhlov/metrics@master
         with:
           filename: metrics.plugin.habits.facts.svg
           token: ${{ secrets.METRICS_TOKEN }}

--- a/.github/workflows/compact-achievement.yml
+++ b/.github/workflows/compact-achievement.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     steps:
       - name: Compact display
-        uses: lowlighter/metrics@latest
+        uses: dkhokhlov/metrics@master
         with:
           filename: metrics.plugin.achievements.compact.svg
           token: ${{ secrets.METRICS_TOKEN }}


### PR DESCRIPTION
lowlighter/metrics is abandoned; switched both workflows to dkhokhlov/metrics@master which fixes the Projects Classic deprecation crash and the habits author destructuring bug.